### PR TITLE
Rewrite WreadIt audio URLs in the Media Library.

### DIFF
--- a/classes/Webinista/class-helpers.php
+++ b/classes/Webinista/class-helpers.php
@@ -420,10 +420,10 @@ final class Helpers {
 	 * @param int|string $audio_id The post ID for the audio attachment.
 	 * @return string
 	 */
-	public static function rewrite_url_with_custom_domain( string $guid, int|string $audio_id ): string {
+	public static function rewrite_url_with_custom_domain( string $guid, int|string|bool $audio_id = false ): string {
 		$url = '';
 
-		if ( 'attachment' !== get_post_type( $audio_id ) ) {
+		if ( $audio_id && 'attachment' !== get_post_type( $audio_id ) ) {
 			return '';
 		}
 

--- a/classes/Webinista/class-wreadit.php
+++ b/classes/Webinista/class-wreadit.php
@@ -62,6 +62,8 @@ final class WreadIt {
 		add_action( 'admin_init', array( $this, 'enqueue_settings_assets' ) );
 
 		add_filter( 'plugin_action_links', array( $this, 'set_plugin_action_links' ), 10, 3 );
+		add_filter( 'wp_get_attachment_url', array( $this, 'rewrite_media_urls' ), 20, 1);
+
 	}
 
 	/**
@@ -98,6 +100,8 @@ final class WreadIt {
 		);
 
 		register_post_type( 'wreadit_revision', $args_revisions );
+
+
 	}
 
 	/**
@@ -811,5 +815,23 @@ final class WreadIt {
 		endif;
 
 		return rest_ensure_response( $response );
+	}
+
+	public function rewrite_media_urls( string $url ): string {
+		$new_url = $url;
+
+		// If the incoming URL contains the aws bucket name setting ...
+		if( stristr( $url, Settings::get_option( '_awss3bucket' ) ) !== false ):
+			$upload_dir = wp_upload_dir();
+
+			if( array_key_exists( 'baseurl', $upload_dir) ):
+				$new_url = trim(str_ireplace( $upload_dir['baseurl'], '', $url ), '/');
+				$new_url = Helpers::rewrite_url_with_custom_domain( $new_url );
+			endif;
+
+
+		endif;
+
+		return $new_url;
 	}
 }


### PR DESCRIPTION
Adds a default parameter to Helpers::rewrite_url_with_custom_domain so it can be used with Helpers::filter_guid or as a standalone method.

Adds a filter for wp_get_attachment_url that uses Helpers::rewrite_url_with_custom_domain to rewrite WreadIt attachment URLs.

Resolves #9